### PR TITLE
Fix/Create pairs without name

### DIFF
--- a/lib/commands/join.js
+++ b/lib/commands/join.js
@@ -1,8 +1,16 @@
+function deriveNameFrom(options) {
+  if(options.pairName) {
+    return options.pairName;
+  }
+
+  return(options.userName);
+}
+
 module.exports = function(options) {
   const newPair = Object.assign(
     {
       channel: options.pairChannel,
-      name: options.pairName,
+      name: deriveNameFrom(options),
       participants: new Set()
     },
 

--- a/lib/commands/join.js
+++ b/lib/commands/join.js
@@ -1,9 +1,7 @@
-function deriveNameFrom(options) {
-  if(options.pairName) {
-    return options.pairName;
-  }
+var _ = require('lodash/fp');
 
-  return(options.userName);
+function deriveNameFrom({pairName, userName}) {
+  return _.first(_.compact([pairName, userName]))
 }
 
 module.exports = function(options) {

--- a/spec/lib/commands/join_spec.js
+++ b/spec/lib/commands/join_spec.js
@@ -2,6 +2,20 @@ const expect = require('chai').expect;
 const join   = require('../../../lib/commands/join');
 
 describe('.join' , function() {
+  it('creates a new pair named for the user who created it',  function() {
+    const options = {
+      userName: 'batman',
+      pairChannel: '#gotham',
+      pairState: undefined
+    }
+
+    const expected = { channel: '#gotham', name: 'batman', participants: new Set(['batman']) }
+
+    const result = join(options)
+
+    expect(result).to.deep.equal(expected);
+  });
+
   it('creates a new pair with the given user and name',  function() {
     const options = {
       userName: 'batman',


### PR DESCRIPTION
Fixes the use case where a user does not specify a channel name