### PR TITLE
Feature/Add Persistence for Application State

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,24 @@
+/* Import pgcrypto so we can auto-generate uuid pks 
+//
+// Note specifically that the extension must be created (loaded) once for
+// each database in which you wish to use it. Once it has been loaded into a
+// running instance of the database server it will be there for use from then
+// on spanning restarts.
+//
+// http://www.starkandwayne.com/blog/uuid-primary-keys-in-postgresql/
+*/
+CREATE DATABASE pairrit;
+
+\c pairrit
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE pairs(
+  id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  body       jsonb,
+  search     tsvector,
+  created_at timestamptz default now()
+);
+CREATE INDEX idx_pairs        on pairs using GIN(body jsonb_path_ops);
+CREATE INDEX idx_pairs_search on pairs using GIN(search);
+

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,27 @@
-const express = require('express');
-const app = express();
-const pairrit = require('./pairrit');
+// main deps
+const express   = require('express');
+const massive   = require('massive');
+const pairrit   = require('./pairrit');
 const pluralize = require('pluralize');
 
-let state = {}
+// helper funcs
+const _  = require('lodash/fp');
+
+const connectionString = process.env.DATABASE_URL || 'postgres://postgres@localhost:5432/pairrit';
+
+const dataStore = new massive.connectSync({connectionString: connectionString});
+
+const persistState = function(state) {
+  dataStore.pairs.saveDoc(state, function(err, result) {
+    return console.log(_.first(_.compact([err, result])));
+  });
+};
+
+const getPairs = function() {
+  return dataStore.pairs.findDoc(function(err, result) {
+    return _.first(_.compact([err, result]));
+  });
+};
 
 const commands = {
   help: function(req, res) {
@@ -41,20 +59,20 @@ const commands = {
   },
 
   join: function(req, res) {
-    state = pairrit.update(state, req.options);
+    persistState(pairrit.update(getPairs, req.options));
 
     res.send(`You have joined the \`${req.options.pairName}\` pair.`);
   },
 
   leave: function(req, res) {
-    state = pairrit.update(state, req.options);
+    persistState(pairrit.update(getPairs, req.options));
 
     res.send(`You have left the \`${req.options.pairName}\` pair.`);
   },
 
   list: function(req, res) {
     {
-      const pairs = pairrit.list(state, req.options.pairChannel);
+      const pairs = pairrit.list(getPairs, req.options.pairChannel);
 
       if (pairs.length > 0) {
         const message = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,25 +3,20 @@ const express   = require('express');
 const massive   = require('massive');
 const pairrit   = require('./pairrit');
 const pluralize = require('pluralize');
+const getPairs  = require('./persistence').getPairs;
+const setPairs  = require('./persistence').setPairs;
 
 // helper funcs
 const _  = require('lodash/fp');
 
+// dataStore
+// move this to `persistence.js` and bind or apply them
+// to the exported functions, somehow
+// (so they become arity 1, and the ds is baked in
+// by `persistence`) - also is this a good idea?
+// what are the tradeoffs?
 const connectionString = process.env.DATABASE_URL || 'postgres://postgres@localhost:5432/pairrit';
-
-const dataStore = new massive.connectSync({connectionString: connectionString});
-
-const persistState = function(state) {
-  dataStore.pairs.saveDoc(state, function(err, result) {
-    return console.log(_.first(_.compact([err, result])));
-  });
-};
-
-const getPairs = function() {
-  return dataStore.pairs.findDoc(function(err, result) {
-    return _.first(_.compact([err, result]));
-  });
-};
+const dataStore        = new massive.connectSync({connectionString: connectionString});
 
 const commands = {
   help: function(req, res) {
@@ -59,13 +54,25 @@ const commands = {
   },
 
   join: function(req, res) {
-    persistState(pairrit.update(getPairs, req.options));
+    const channel = req.options.pairChannel;
+    // seems like these are implementation details
+    // that should be handled by the join command
+    //
+    // const pairHash = req.options.pairHash
+    // const pairCurrentState = getPair({hash: pairHash});
+
+    // maybe for this use-case we do want
+    // the ability to find and return (to update)
+    // a single pair, eg by Pair Name
+    // (which we would then have to determine sooner)
+    // or Hash (which we would also have to determine sooner)
+    setPairs(pairrit.update(getPairs(channel), req.options), dataStore);
 
     res.send(`You have joined the \`${req.options.pairName}\` pair.`);
   },
 
   leave: function(req, res) {
-    persistState(pairrit.update(getPairs, req.options));
+    setPairs(pairrit.update(getPairs, req.options));
 
     res.send(`You have left the \`${req.options.pairName}\` pair.`);
   },

--- a/lib/persistence.js
+++ b/lib/persistence.js
@@ -1,0 +1,4 @@
+module.exports = {
+  getPairs: require('./persistence/getPairs'),
+  setPairs: require('./persistence/setPairs')
+};

--- a/lib/persistence/getPairs.js
+++ b/lib/persistence/getPairs.js
@@ -1,5 +1,10 @@
-module.exports = function(collection) {
-  return collection.findDoc(function(err, result) {
+module.exports = function(channelName, collection) {
+  const query = {
+    channel: channelName,
+    "participants <>": []
+  };
+
+  return collection.findDoc(query, function(err, result) {
     return _.first(_.compact([err, result]));
   });
 };

--- a/lib/persistence/getPairs.js
+++ b/lib/persistence/getPairs.js
@@ -1,0 +1,5 @@
+module.exports = function(collection) {
+  return collection.findDoc(function(err, result) {
+    return _.first(_.compact([err, result]));
+  });
+};

--- a/lib/persistence/setPairs.js
+++ b/lib/persistence/setPairs.js
@@ -1,0 +1,9 @@
+module.exports = function(pair, collection) {
+  collection.saveDoc(pair, function(err, result) {
+    // no-op
+    return null;
+  });
+
+  return null;
+};
+

--- a/package.json
+++ b/package.json
@@ -21,9 +21,5 @@
     "lodash": "^4.15.0",
     "massive": "^2.5.0",
     "pluralize": "^3.0.0"
-  },
-  "scripts": {
-    "start": "node server.js",
-    "test": "mocha --recursive spec/"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,14 +5,15 @@
   "main": "server.js",
   "scripts": {
     "start": "NODE_ENV=dev  node server.js",
-    "test":  "NODE_ENV=test mocha --recursive spec/"
+    "test": "NODE_ENV=test mocha --recursive spec/"
   },
   "author": "J. Chambers, A. Deschamps, C. Flanigan",
   "license": "ISC",
   "devDependencies": {
     "chai": "^3.5.0",
     "mocha": "^3.0.2",
-    "sinon": "^1.17.6"
+    "sinon": "^1.17.6",
+    "testdouble": "^1.8.0"
   },
   "dependencies": {
     "body-parser": "^1.15.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "crypto-js": "^3.1.6",
     "express": "^4.14.0",
     "lodash": "^4.15.0",
+    "massive": "^2.5.0",
     "pluralize": "^3.0.0"
   },
   "scripts": {

--- a/spec/lib/persistence_spec.js
+++ b/spec/lib/persistence_spec.js
@@ -1,17 +1,3 @@
-
-    //
-    // MOVE TO RETRIEVE TEST
-    // to list pairs
-    // we fetch all pairs (for a given channel)
-    // where participants is not empty
-    //
-    // MOVE TO UPDATE?
-    // For finding a pair to update, we search on the
-    // hash, and sort by the most recent record (last
-    // persisted state), and modify that copy
-    // Would this cause a race condition? Maybe...
-
-
 // testing dependencies
 const expect = require('chai').expect;
 const td     = require('testdouble');
@@ -19,6 +5,7 @@ const td     = require('testdouble');
 // our system under test
 const persistence = require('../../lib/persistence');
 
+//
 // WE ALWAYS MOVE FORWARD IN TIME
 // creating history as we go
 // all that we care about
@@ -30,6 +17,19 @@ const persistence = require('../../lib/persistence');
 // and the previous state remains intact
 // immutable over time
 //
+// GET ALL THE PAIRS
+// (for a given channel)
+// where Participants is not empty
+//
+// we only care about pairs with participants
+// because when the last person leaves
+// we store the last copy of that pair with empty
+// participants
+// and as soon as someone joins
+// we make and store a new copy
+// with the creator as the only participant
+//
+
 describe('Persistence', function() {
   describe('adding a pair to history' , function() {
     it('persists a pair to the passed in datastore',  function() {
@@ -40,7 +40,7 @@ describe('Persistence', function() {
         participants: ['alfred', 'batman', 'you', 'me']
       };
 
-      // stub out our datastore connection
+      // stub our datastore connection
       var mockSaveDoc = td.function()
 
       const mockCollection = {
@@ -56,13 +56,6 @@ describe('Persistence', function() {
   });
 
   describe('retrieving pairs' , function() {
-    // we only care about pairs with participants
-    // because when the last person leaves
-    // we store the last copy of that pair with empty
-    // participants
-    // and as soon as someone joins
-    // we make and store a new copy
-    // with the creator as the only participant
     it('returns all pairs with participants',  function() {
       const mockPairs = [{
         channel:      '#gotham',
@@ -70,15 +63,15 @@ describe('Persistence', function() {
         name:         'batcave',
         participants: ['alfred', 'batman', 'you', 'me']
       }, {
-        channel:      '#arkham',
-        hash:         '12345asdf',
-        name:         'staff',
-        participants: ['amadeus', 'jeremiah', 'harleen']
-      }, {
-        channel:      '#wayne-enterprises',
+        channel:      '#gotham',
         hash:         '0123abcde',
-        name:         'aerospace',
-        participants: ['lucius']
+        name:         'wayne-enterprises',
+        participants: ['lucius', 'bruce']
+      }, {
+        channel:      '#gotham',
+        hash:         '12345asdf',
+        name:         'arkham',
+        participants: ['amadeus', 'jeremiah', 'harleen']
       }];
 
       // stub out our datastore connection
@@ -94,7 +87,7 @@ describe('Persistence', function() {
         thenReturn(mockPairs);
 
       // call our method
-      var result = persistence.getPairs(mockCollection);
+      var result = persistence.getPairs(channel, mockCollection);
 
       expect(result).to.eql(mockPairs);
 

--- a/spec/lib/persistence_spec.js
+++ b/spec/lib/persistence_spec.js
@@ -1,0 +1,112 @@
+
+    //
+    // MOVE TO RETRIEVE TEST
+    // to list pairs
+    // we fetch all pairs (for a given channel)
+    // where participants is not empty
+    //
+    // MOVE TO UPDATE?
+    // For finding a pair to update, we search on the
+    // hash, and sort by the most recent record (last
+    // persisted state), and modify that copy
+    // Would this cause a race condition? Maybe...
+
+
+// testing dependencies
+const expect = require('chai').expect;
+const td     = require('testdouble');
+
+// our system under test
+const persistence = require('../../lib/persistence');
+
+// WE ALWAYS MOVE FORWARD IN TIME
+// creating history as we go
+// all that we care about
+// is that a copy of the most recent state
+// of a pair is available
+// we use the most recent available copy
+// to make a new copy with our state change
+// we persist this new copy
+// and the previous state remains intact
+// immutable over time
+//
+describe('Persistence', function() {
+  describe('adding a pair to history' , function() {
+    it('persists a pair to the passed in datastore',  function() {
+      const newPair = {
+        channel:      '#gotham',
+        sha:          'asdf12345',
+        name:         'batcave',
+        participants: ['alfred', 'batman', 'you', 'me']
+      };
+
+      // stub out our datastore connection
+      var mockSaveDoc = td.function()
+
+      const mockCollection = {
+        saveDoc: mockSaveDoc
+      };
+
+      // call our method
+      persistence.setPairs(newPair, mockCollection);
+
+      // verify db was called as expected
+      td.verify(mockSaveDoc(newPair, td.matchers.isA(Function)));
+    });
+  });
+
+  describe('retrieving pairs' , function() {
+    // we only care about pairs with participants
+    // because when the last person leaves
+    // we store the last copy of that pair with empty
+    // participants
+    // and as soon as someone joins
+    // we make and store a new copy
+    // with the creator as the only participant
+    it('returns all pairs with participants',  function() {
+      const mockPairs = [{
+        channel:      '#gotham',
+        hash:         'asdf12345',
+        name:         'batcave',
+        participants: ['alfred', 'batman', 'you', 'me']
+      }, {
+        channel:      '#arkham',
+        hash:         '12345asdf',
+        name:         'staff',
+        participants: ['amadeus', 'jeremiah', 'harleen']
+      }, {
+        channel:      '#wayne-enterprises',
+        hash:         '0123abcde',
+        name:         'aerospace',
+        participants: ['lucius']
+      }];
+
+      // stub out our datastore connection
+      var mockFindDoc = td.function()
+
+      const mockCollection = {
+        findDoc: mockFindDoc
+      };
+
+      // figure out how to make a where clause
+      // to verify that participants is not null
+      td.when(mockFindDoc(td.matchers.isA(Object))).
+        thenReturn(mockPairs);
+
+      // call our method
+      var result = persistence.getPairs(mockCollection);
+
+      expect(result).to.eql(mockPairs);
+
+      // maybe move this to a separate test
+      // to verify db was called as expected
+      // (with the where clause)
+      // and make the 'returns pairs'
+      // test verify that we return whatever
+      // comes back from the mocked out call
+      // here
+      // td.verify(mockFindDoc(newPair, td.matchers.isA(Function)));
+    });
+  });
+});
+

--- a/spec/lib/persistence_spec.js
+++ b/spec/lib/persistence_spec.js
@@ -56,7 +56,7 @@ describe('Persistence', function() {
   });
 
   describe('retrieving pairs' , function() {
-    it('returns all pairs with participants',  function() {
+    it('returns the result from the call to persistence',  function() {
       const mockPairs = [{
         channel:      '#gotham',
         hash:         'asdf12345',
@@ -87,7 +87,7 @@ describe('Persistence', function() {
         thenReturn(mockPairs);
 
       // call our method
-      var result = persistence.getPairs(channel, mockCollection);
+      var result = persistence.getPairs('gotham', mockCollection);
 
       expect(result).to.eql(mockPairs);
 
@@ -98,7 +98,47 @@ describe('Persistence', function() {
       // test verify that we return whatever
       // comes back from the mocked out call
       // here
-      // td.verify(mockFindDoc(newPair, td.matchers.isA(Function)));
+
+    });
+
+    it('retreives pairs with participants scoped to a channel', function() {
+      // stub out our datastore connection
+      var mockFindDoc = td.function()
+
+      const mockCollection = {
+        findDoc: mockFindDoc
+      };
+
+      // exercise our code under test
+      persistence.getPairs('gotham', mockCollection);
+
+      // verify our call to persistence binding
+      // with expected attributes
+      const scope = td.matchers.contains({
+        channel: 'gotham'
+      });
+
+      td.verify(mockFindDoc(scope, td.matchers.isA(Function)));
+    });
+
+    it('only fetches pairs with participants', function() {
+      // stub out our datastore connection
+      var mockFindDoc = td.function()
+
+      const mockCollection = {
+        findDoc: mockFindDoc
+      };
+
+      // exercise code under test
+      persistence.getPairs('gotham', mockCollection);
+
+      // verify our call to persistence binding
+      // with expected attributes
+      const scope = td.matchers.contains({
+        "participants <>": []
+      });
+
+      td.verify(mockFindDoc(scope, td.matchers.isA(Function)));
     });
   });
 });


### PR DESCRIPTION
**WIP**

Adds 
* Database bindings for PostgreSQL
* A lightweight schema with a table for pairs using `jsonb` datatype for object body
* Helper functions to store and retrieve application state

All existing tests are passing, but persistence functions are not tested yet.

Database connection string is not yet parameterized.