### PR TITLE
Respond ephemerally to the `list` command

### DIFF
--- a/app/models/command/list.rb
+++ b/app/models/command/list.rb
@@ -13,7 +13,7 @@ class Command::List
 
     if pairs.any?
       message = {
-        response_type: 'in_channel',
+        response_type: 'ephemeral',
         text: 'The following pairs are in progress:',
         attachments: pairs.map do |pair|
           {


### PR DESCRIPTION
Only the Person who issues `/pair list` sees the response.